### PR TITLE
documentation/warning updates

### DIFF
--- a/README.md
+++ b/README.md
@@ -32,6 +32,14 @@ USING pipeline
   - check the result files in final/
   - intermediate files are stored in intermediate/ and can safely be deleted after processing has completed
 
+CAVEATS
+========
+This tool requires a fair number of other tools to be installed.  The shell script checks for them, and will try to give you breadcrumbs as to how to solve any of the issues it finds (e.g. where to find bwa).
+
+If your machine/instance has less than 4GB of RAM, you'll want to modify the script so it uses chr6.fa as the reference genomic, install of all_chr.fa.   Make sure those files are indexed.  This script does not do the indexing for you.
+
+This is a work in progress, but we welcome improvements and questions.  Please feel free to file issues in github.
+
 DEBUGGING
 ========
 Elapsed times, STDOUT and STDERR messages are stored in files named timedata.[0-9]+ -- that is, timedata, followed by a numeric string derived from the PID of the splitter.bash script. 

--- a/process_fastq.bash
+++ b/process_fastq.bash
@@ -35,6 +35,9 @@ REFDIR=/opt/data/tutorial/grch38_fasta_reference
 ## note that REFDIR may require customization to your circumstances, as
 ## well as TOOLDIR
 REFCHR=all_chr.fa
+## change above to just chromosome6 (chr6.fa) if you have less than 4GB or
+## memory.  Frankly, we've seen issues even on machines _with_ 4GB, so
+## for safeties sake, make sure you've got more memory.
 TMPDIR=~/tmp
 
 ABORT=0


### PR DESCRIPTION
Documentation only updates to warn that things will fall apart if you're trying to use the entire human genome as  REFCHR, and you have 4GB of RAM or less.
