### PR TITLE
Fix issue #41 -- reverse complement minus strand HLA genes so they can b...

### DIFF
--- a/splice-bam.groovy
+++ b/splice-bam.groovy
@@ -172,10 +172,16 @@ if (options.c) {
     def cdna = ""
     exons.each { index, list ->
       best = list.sort { it.sequence.seqString().length() } .first()
+      
       cdna += best.sequence.seqString()
     }
 
     println "${contig}"
+    
+    if(!(options.g.equals("HLA-A") || options.g.equals("HLA-DPB1"))) {
+      cdna = DNATools.reverseComplement(DNATools.createDNA(cdna)).seqString() 
+    }
+
     println "${cdna.toUpperCase()}"
   }
 }


### PR DESCRIPTION
...e properly interpreted. Warning: this is a hack and should be replaced with properly configured tool where filtered regions include the strand (a la GFF or HML)
