### PR TITLE
Fix bug #56, which is caused by improper formatting of regions files for...

### DIFF
--- a/splice-bam.groovy
+++ b/splice-bam.groovy
@@ -74,13 +74,7 @@ if (options.b) {
 exons = [:]
 
 new File(options.x).each { line ->
-  def fields = line.split("\t")
-  if(!(fields.size() >= 2)) {
-    println "input file ${options.x} is not properly formatted"
-    System.exit(-1)
-  }
-  def index = fields[0]
-  def coordinate = fields[1]
+  def (index, coordinate) = line.split("\\s+")
   def locus = FeatureParser.parseLocus(coordinate)
   exons[index] = Allele.builder()
                   .withContig(locus.getContig())


### PR DESCRIPTION
... filtering -- in this case spaces instead of tabs between index and coordinate fields produced an ArrayOutOfBoundsException. Sometimes formatting issues arise when copying files around. I put an error message into the code (Mark will have to reformat the regions files in /mnt/common/)
