### PR TITLE
Samplecount v processorcount disparity fix

### DIFF
--- a/splitter.bash
+++ b/splitter.bash
@@ -1,4 +1,4 @@
-#!/bin/bash -x
+#!/bin/bash
 
 #
 #    pipeline  Consensus assembly and allele interpretation pipeline.


### PR DESCRIPTION
Fixes issue #53 on RHEL and OSX, including cases wherein there are fewer samples than cores, or the number of samples does not divide evenly into the number of cores.

As a result of these changes, some cases exist wherein core utilization will be at (n-1) instead of at n.  However, splitter will no longer attempt to use more cores than exist.
