### PR TITLE
redhat lacks pidof.  safer/easier to just not delete boilerplate header

### DIFF
--- a/process_fastq.bash
+++ b/process_fastq.bash
@@ -157,9 +157,4 @@ fi
   samtools mpileup -f ${REFDIR}/${REFCHR}.gz ${final}.reads.bwa.sorted.bam > ${final}.reads.bwa.sorted.vcf
 done
 
-#begin cleanup
-rm -f ${BOILERPLATE_HEADER}
-
-#end cleanup
-
 echo "completed processing file ${SOURCEFILE}"


### PR DESCRIPTION
fixes issue #70 
I just removed the step where we delete the boilerplate header -- since we're working in our own directory, there is little reason to delete the headerfile anymore.  I only did it in the first place because we had the chance of conflicting with a different user.
