### PR TITLE
fix issue 76 with the power of regex

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,7 +16,7 @@ USING pipeline
  - edit splitter.bash to include the correct path to your copy of the pipeline
     note -- splitter.bash will not run unless you set this value.
  - ensure your data is in the format that splitter and process_fastq expect:
-     - all data files to be processed must be in fastq format, with a filename ending in .fastq
+     - all data files to be processed must be in fastq format, with a filename ending in .fastq or .fq
      - your directory of data must have all fastq files in a subdirectory named raw/ .  Optionally, you can organize your fastq files in subdirectories of raw/, but this may add complexity.
      - avoid having underscores in subdirectory names under raw/
      - any non-fastq files in the raw/ subdirectory will be ignored

--- a/splitter.bash
+++ b/splitter.bash
@@ -142,7 +142,8 @@ if [[ $ABORT -gt 0 ]]; then
   exit 1
 fi
 
-if [[ $(find ${RAWDIR} -type f | grep -c fastq) -eq 0 ]]; then
+# now, we accept fastq OR fq, but we want that as a suffix.
+if [[ $(find ${RAWDIR} -type f | grep -cie '\(fq\|fastq\)$') -eq 0 ]]; then
   echo "no fastq files found in ${RAWDIR}.  Aborting."
   exit 1
 fi
@@ -164,7 +165,7 @@ rm ${SCRATCHFILE}  2>/dev/null
 if [[ ${DEBUG}"x" != "x" ]]; then
   echo "MASTERWORKFILE = ${MASTERWORKFILE}"
 fi
-for MYIDENTIFIER in $(find ${RAWDIR} -name '*.fastq' -print -type f | sed -e 's/R[12]/RX/g' | uniq); do if [[ ${DEBUG}"x" == "1x" ]]; then
+for MYIDENTIFIER in $(find ${RAWDIR} \( -iname '*.fastq' -o -iname '*.fq' \) -print -type f | sed -e 's/R[12]/RX/g' | uniq); do if [[ ${DEBUG}"x" == "1x" ]]; then
     echo ${MYIDENTIFIER}
   fi
   echo ${MYIDENTIFIER} >> ${SCRATCHFILE}


### PR DESCRIPTION
fixes issue #76 wherein we did not allow users to name their files .fq.
Also, removes case-sensitivity on the check for fastq and fq files.
So if you MUST name your fastq files Blah_blah_blah.FaStQ , you can do that now, and pipeline will still accept them.
